### PR TITLE
Optimized test coverage reporting and refactored _mp_manager init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 # Project metdata section. Provides the general ID information about the project.
 [project]
 name = "ataraxis-data-structures"
-version = "3.0.1"
+version = "3.0.2"
 description = "Provides classes and structures for storing, manipulating, and sharing data between Python processes."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -213,11 +213,6 @@ source = ["src/", ".tox/*/lib/python*/site-packages/"]
 # Same as above, specifies the output directory for the coverage .html report
 [tool.coverage.html]
 directory = "reports/coverage_html"
-
-# Optimizes coverage generation for parallel testing
-[tool.coverage.run]
-parallel = true
-concurrency = ["multiprocessing", "thread"]
 
 # Specifies additional ignore directives
 [tool.coverage.report]

--- a/src/ataraxis_data_structures/data_loggers/serialized_data_logger.py
+++ b/src/ataraxis_data_structures/data_loggers/serialized_data_logger.py
@@ -159,6 +159,8 @@ class DataLogger:
     ) -> None:
         # Initializes a variable that tracks whether the class has been started.
         self._started: bool = False
+        # Since __del__ now terminates the manager, it is a good idea to keep it high on the initialization order
+        self._mp_manager: SyncManager = Manager()
 
         # Ensures numeric inputs are not negative.
         self._process_count: int = max(1, process_count)
@@ -174,7 +176,6 @@ class DataLogger:
         ensure_directory_exists(self._output_directory)  # This also ensures input is a valid Path object
 
         # Sets up the multiprocessing Queue to be shared by all logger and data source processes.
-        self._mp_manager: SyncManager = Manager()
         self._input_queue: MPQueue = self._mp_manager.Queue()  # type: ignore
 
         self._terminator_array: SharedMemoryArray | None = None

--- a/src/ataraxis_data_structures/data_loggers/serialized_data_logger.pyi
+++ b/src/ataraxis_data_structures/data_loggers/serialized_data_logger.pyi
@@ -104,13 +104,13 @@ class DataLogger:
     """
 
     _started: bool
+    _mp_manager: Incomplete
     _process_count: Incomplete
     _thread_count: Incomplete
     _sleep_timer: Incomplete
     _name: Incomplete
     _exist_ok: Incomplete
     _output_directory: Incomplete
-    _mp_manager: Incomplete
     _input_queue: Incomplete
     _terminator_array: Incomplete
     _logger_processes: Incomplete


### PR DESCRIPTION
Since multiprocessing manager (_mp_manager) is now terminated as part of __del__, it makes sense to have it high in the initialization order. This should solve a small set of problems observed in upstream packages, where shutting down DataLogger during initialization triggers an error during __del__ runtime. 
 
 Also removed additional coverage optimizations, as they caused test code to be covered too, misleadingly dropping the overall coverage value.