### PR TITLE
Fixed onset timestamp deserialization to use unsigned 64-bit integers.

### DIFF
--- a/src/ataraxis_data_structures/data_loggers/log_archive_reader.py
+++ b/src/ataraxis_data_structures/data_loggers/log_archive_reader.py
@@ -114,8 +114,8 @@ class LogArchiveReader:
 
                 # A timestamp value of 0 indicates the onset message.
                 if timestamp_value == 0:
-                    # The payload contains the onset timestamp as a signed 64-bit integer.
-                    onset = np.uint64(entry[1 + self._TIMESTAMP_BYTE_SIZE :].view(np.int64).item())
+                    # The payload contains the onset timestamp as an unsigned 64-bit integer.
+                    onset = np.uint64(entry[1 + self._TIMESTAMP_BYTE_SIZE :].view(np.uint64).item())
 
                     # Caches the message keys excluding the onset message for later use.
                     self._message_keys = file_list[number + 1 :]

--- a/tests/data_loggers/log_archive_reader_test.py
+++ b/tests/data_loggers/log_archive_reader_test.py
@@ -39,7 +39,7 @@ def _create_onset_message(source_id: int, onset_us: int) -> NDArray[np.uint8]:
     """
     source_bytes = np.array([source_id], dtype=np.uint8)
     timestamp_bytes = convert_scalar_to_bytes(value=0, dtype=np.dtype(np.uint64))
-    onset_bytes = convert_scalar_to_bytes(value=onset_us, dtype=np.dtype(np.int64))
+    onset_bytes = convert_scalar_to_bytes(value=onset_us, dtype=np.dtype(np.uint64))
     return np.concatenate([source_bytes, timestamp_bytes, onset_bytes])
 
 
@@ -445,8 +445,8 @@ class TestLogArchiveReaderIntegration:
         # Gets the current UTC timestamp for the onset message.
         onset_us = get_timestamp(output_format=TimestampFormats.INTEGER, precision=TimestampPrecisions.MICROSECOND)
 
-        # Submits the onset message first (timestamp=0, payload contains UTC epoch as int64).
-        onset_payload = convert_scalar_to_bytes(value=onset_us, dtype=np.dtype(np.int64))
+        # Submits the onset message first (timestamp=0, payload contains UTC epoch as uint64).
+        onset_payload = convert_scalar_to_bytes(value=onset_us, dtype=np.dtype(np.uint64))
         onset_packed = LogPackage(source_id=np.uint8(1), acquisition_time=np.uint64(0), serialized_data=onset_payload)
         logger.input_queue.put(onset_packed)
 


### PR DESCRIPTION
-- Changed LogArchiveReader onset decoding from signed int64 to unsigned uint64 to match the ataraxis-time serialization contract. -- Updated log archive reader tests to construct onset payloads as uint64.