### PR TITLE
Fixed ProcessingTracker job state retention and registry alignment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,7 @@ if __name__ == "__main__":
     # as part of its runtime. While having advantages for real-time data logging, this format of storing the data
     # is not ideal for later data transfer and manipulation. Therefore, it is recommended to always use the
     # assemble_log_archives() function to aggregate the individual .npy files into one or more .npz archives.
-    assemble_log_archives(
-        log_directory=logger.output_directory, remove_sources=True, memory_mapping=True, verbose=True
-    )
+    assemble_log_archives(log_directory=logger.output_directory, remove_sources=True, memory_mapping=True, verbose=True)
 
     # The archive assembly creates a single .npz file named after the source_id (1_log.npz), using all available
     # .npy files. Generally, each unique data source is assembled into a separate .npz archive.
@@ -573,20 +571,23 @@ tracker = ProcessingTracker(file_path=Path("/path/to/tracker.yaml"))
 
 # Initializes jobs to be tracked (each job is a tuple of (job_name, specifier))
 # Specifiers differentiate instances of the same job (e.g., different data batches)
-job_ids = tracker.initialize_jobs([
-    ("process_video", "session_001"),
-    ("process_video", "session_002"),
-    ("extract_frames", "session_001"),
-    ("extract_frames", "session_002"),
-    ("generate_report", ""),  # Empty specifier for jobs without batches
-])
+job_ids = tracker.initialize_jobs(
+    [
+        ("process_video", "session_001"),
+        ("process_video", "session_002"),
+        ("extract_frames", "session_001"),
+        ("extract_frames", "session_002"),
+        ("generate_report", ""),  # Empty specifier for jobs without batches
+    ]
+)
 
 print(f"Initialized {len(job_ids)} jobs")
 ```
 
 For pipelines that run a selectable subset of their jobs across invocations, `align_jobs()` reconciles an existing
 tracker with the jobs a given invocation intends to run. It additively registers any missing jobs, leaves
-already-tracked jobs untouched, and rebuilds the tracker when it holds entries outside the provided job universe.
+already-tracked jobs untouched, and discards only those entries that fall outside the provided job universe.
+Requesting a job that is absent from the universe raises a `ValueError`.
 
 ```python
 from pathlib import Path
@@ -722,7 +723,7 @@ from ataraxis_data_structures import calculate_directory_checksum
 checksum = calculate_directory_checksum(
     directory=Path("/path/to/data"),
     num_processes=None,  # Uses all available CPU cores minus 2 reserved cores
-    progress=True,       # Shows progress bar
+    progress=True,  # Shows progress bar
     save_checksum=True,  # Saves to ax_checksum.txt in the directory
 )
 print(f"Directory checksum: {checksum}")
@@ -748,19 +749,19 @@ from ataraxis_data_structures import transfer_directory
 transfer_directory(
     source=Path("/path/to/source"),
     destination=Path("/path/to/destination"),
-    num_threads=4,           # Uses 4 threads for parallel copy
-    verify_integrity=True,   # Verifies checksum after transfer
-    remove_source=False,     # Keeps source after transfer
-    progress=True,           # Shows progress bar
+    num_threads=4,  # Uses 4 threads for parallel copy
+    verify_integrity=True,  # Verifies checksum after transfer
+    remove_source=False,  # Keeps source after transfer
+    progress=True,  # Shows progress bar
 )
 
 # Moves data (transfers and removes source)
 transfer_directory(
     source=Path("/path/to/source"),
     destination=Path("/path/to/destination"),
-    num_threads=0,           # Uses all available CPU cores minus a few reserved for the host
+    num_threads=0,  # Uses all available CPU cores minus a few reserved for the host
     verify_integrity=True,
-    remove_source=True,      # Removes source after successful transfer
+    remove_source=True,  # Removes source after successful transfer
 )
 ```
 

--- a/envs/axds_dev_lin.yml
+++ b/envs/axds_dev_lin.yml
@@ -4,43 +4,43 @@ channels:
 dependencies:
   - _openmp_mutex=4.5=20_gnu
   - bzip2=1.0.8=hda65f42_9
-  - ca-certificates=2026.5.20=hbd8a1cb_0
-  - cachetools=7.1.4=pyhd8ed1ab_0
+  - ca-certificates=2026.7.22=hbd8a1cb_0
+  - cachetools=7.1.6=pyhd8ed1ab_0
   - colorama=0.4.6=pyhd8ed1ab_1
   - distlib=0.4.3=pyhcf101f3_0
-  - filelock=3.29.4=pyhd8ed1ab_0
+  - filelock=3.32.0=pyhd8ed1ab_0
+  - icu=78.3=h54a6638_2
   - importlib-metadata=9.0.0=pyhcf101f3_0
-  - ld_impl_linux-64=2.45.1=default_hbd61a6d_102
+  - ld_impl_linux-64=2.46.1=default_hbd61a6d_102
   - libexpat=2.8.1=hecca717_1
   - libffi=3.5.2=h3435931_0
-  - libgcc=15.2.0=he0feb66_19
-  - libgomp=15.2.0=he0feb66_19
+  - libgcc=15.2.0=he0feb66_20
+  - libgomp=15.2.0=he0feb66_20
   - liblzma=5.8.3=hb03c661_0
   - libmpdec=4.0.0=hb03c661_1
-  - libsqlite=3.53.2=h0c1763c_0
-  - libstdcxx=15.2.0=h934c35e_19
-  - libuuid=2.42.1=h5347b49_0
+  - libsqlite=3.53.4=hf4e2dac_0
+  - libstdcxx=15.2.0=h934c35e_20
+  - libuuid=2.42.2=h5347b49_0
   - libzlib=1.3.2=h25fd6f3_2
   - ncurses=6.6=hdb14827_0
   - openssl=3.6.3=h35e630c_0
   - packaging=26.2=pyhc364b38_0
   - pip=26.1.2=pyh145f28c_0
-  - platformdirs=4.10.0=pyhcf101f3_0
+  - platformdirs=4.11.0=pyhcf101f3_0
   - pluggy=1.6.0=pyhf9edf01_1
-  - pyproject-api=1.10.1=pyhcf101f3_0
-  - python=3.14.6=habeac84_100_cp314
-  - python-discovery=1.4.2=pyhcf101f3_0
-  - python-uv=0.11.21=pyhcf101f3_0
+  - pyproject-api=1.11.0=pyhcf101f3_0
+  - python=3.14.6=habeac84_101_cp314
+  - python-discovery=1.5.0=pyhcf101f3_0
   - python_abi=3.14=8_cp314
   - readline=8.3=h853b02a_0
-  - tk=8.6.13=noxft_h366c992_103
+  - tk=8.6.13=noxft_hd70dff1_3
   - tomli-w=1.2.0=pyhd8ed1ab_0
-  - tox=4.55.1=pyhcf101f3_0
-  - tox-uv=1.29.0=pyhd8ed1ab_0
-  - typing_extensions=4.15.0=pyhcf101f3_0
-  - tzdata=2025c=hc9c84f9_1
-  - uv=0.11.21=h26efc2c_0
-  - virtualenv=21.5.0=pyhcf101f3_0
+  - tox=4.58.0=pyhcf101f3_0
+  - tox-uv=1.36.0=pyhcf101f3_0
+  - typing_extensions=4.16.0=pyhcf101f3_0
+  - tzdata=2026c=h151e31d_0
+  - uv=0.11.32=h2112641_0
+  - virtualenv=21.7.0=pyhcf101f3_0
   - zipp=4.1.0=pyhcf101f3_0
   - zstd=1.5.7=hb78ec9c_6
   - pip:
@@ -53,22 +53,22 @@ dependencies:
     - Sphinx==9.1.0
     - accessible-pygments==0.0.5
     - alabaster==1.0.0
-    - ast_serialize==0.5.0
+    - ast_serialize==0.6.0
     - ataraxis-automation==8.1.1
-    - ataraxis-base-utilities==6.0.1
-    - ataraxis-time==6.0.1
+    - ataraxis-base-utilities==6.0.2
+    - ataraxis-time==6.0.2
     - babel==2.18.0
     - bashlex==0.18
     - beautifulsoup4==4.15.0
-    - bracex==2.6
+    - bracex==3.0.1
     - breathe==4.36.0
     - build==1.5.0
-    - certifi==2026.5.20
-    - cffi==2.0.0
-    - charset-normalizer==3.4.7
-    - cibuildwheel==4.1.0
-    - click==8.4.1
-    - coverage==7.14.1
+    - certifi==2026.7.22
+    - cffi==2.1.0
+    - charset-normalizer==3.4.9
+    - cibuildwheel==4.1.1
+    - click==8.4.2
+    - coverage==7.15.2
     - cryptography==49.0.0
     - dacite==1.9.2
     - dependency-groups==1.3.1
@@ -77,32 +77,32 @@ dependencies:
     - furo==2025.12.19
     - gh==0.0.4
     - gitdb==4.0.12
-    - hatchling==1.30.1
-    - humanize==4.15.0
+    - hatchling==1.31.0
+    - humanize==4.16.0
     - id==1.6.1
     - idna==3.18
     - imagesize==2.0.0
     - iniconfig==2.3.0
     - jaraco.classes==3.4.0
     - jaraco.context==6.1.2
-    - jaraco.functools==4.5.0
+    - jaraco.functools==4.6.0
     - jeepney==0.9.0
     - junitparser==5.0.1
     - keyring==25.7.0
-    - librt==0.11.0
+    - librt==0.13.0
     - loguru==0.7.3
     - markdown-it-py==4.2.0
     - mdurl==0.1.2
     - more-itertools==11.1.0
-    - mypy==2.1.0
+    - mypy==2.3.0
     - mypy_extensions==1.1.0
-    - nanobind==2.12.0
-    - nh3==0.3.5
-    - numpy==2.4.6
+    - nanobind==2.13.0
+    - nh3==0.3.6
+    - numpy==2.5.1
     - pathspec==1.1.1
     - pycparser==3.0
     - pyproject_hooks==1.2.0
-    - pytest==9.1.0
+    - pytest==9.1.1
     - pytest-cov==7.1.0
     - pytest-xdist==3.8.0
     - readme_renderer==45.0
@@ -111,12 +111,12 @@ dependencies:
     - rfc3986==2.0.0
     - rich==15.0.0
     - roman-numerals==4.1.0
-    - ruff==0.15.17
+    - ruff==0.16.0
     - scikit_build_core==0.12.2
     - smmap==5.0.2
     - snowballstemmer==3.1.1
-    - soupsieve==2.8.4
-    - sphinx-autodoc-typehints==3.11.0
+    - soupsieve==2.9.1
+    - sphinx-autodoc-typehints==3.13.0
     - sphinx-basic-ng==1.0.0b2
     - sphinx-click==6.2.0
     - sphinxcontrib-applehelp==2.0.0
@@ -125,10 +125,12 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==2.0.0
     - sphinxcontrib-serializinghtml==2.0.0
-    - tqdm==4.68.2
+    - tox-uv==1.36.0
+    - tqdm==4.69.1
     - trove-classifiers==2026.6.1.19
     - twine==6.2.0
-    - types-PyYAML==6.0.12.20260518
+    - types-PyYAML==6.0.12.20260724
     - urllib3==2.7.0
-    - xxhash==3.7.0
+    - uv==0.11.32
+    - xxhash==3.8.1
 

--- a/envs/axds_dev_lin_spec.txt
+++ b/envs/axds_dev_lin_spec.txt
@@ -21,8 +21,8 @@ https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
 
 
 https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-https://conda.anaconda.org/conda-forge/noarch/cachetools-7.1.4-pyhd8ed1ab_0.conda
+https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+https://conda.anaconda.org/conda-forge/noarch/cachetools-7.1.6-pyhd8ed1ab_0.conda
 
 
 
@@ -36,12 +36,13 @@ https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
 https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
 
 
-https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.4-pyhd8ed1ab_0.conda
+https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.0-pyhd8ed1ab_0.conda
 
 
 
 
 
+https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
 
 
 
@@ -53,17 +54,17 @@ https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f
 
 
 
-https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
 https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
 https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_20.conda
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_20.conda
 https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
 
-https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
-https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_20.conda
+https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
 
 
@@ -79,17 +80,16 @@ https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
 https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
 
 https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
 https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
 
-https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.10.1-pyhcf101f3_0.conda
+https://conda.anaconda.org/conda-forge/noarch/pyproject-api-1.11.0-pyhcf101f3_0.conda
 
 
 
 
-https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
-https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.2-pyhcf101f3_0.conda
-https://conda.anaconda.org/conda-forge/noarch/python-uv-0.11.21-pyhcf101f3_0.conda
+https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_101_cp314.conda
+https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.5.0-pyhcf101f3_0.conda
 https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
 https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
 
@@ -112,19 +112,19 @@ https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
 
 
 
-https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
 https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
-https://conda.anaconda.org/conda-forge/noarch/tox-4.55.1-pyhcf101f3_0.conda
-https://conda.anaconda.org/conda-forge/noarch/tox-uv-1.29.0-pyhd8ed1ab_0.conda
+https://conda.anaconda.org/conda-forge/noarch/tox-4.58.0-pyhcf101f3_0.conda
+https://conda.anaconda.org/conda-forge/noarch/tox-uv-1.36.0-pyhcf101f3_0.conda
 
 
 
 
-https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
 
-https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.21-h26efc2c_0.conda
-https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.5.0-pyhcf101f3_0.conda
+https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.32-h2112641_0.conda
+https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.7.0-pyhcf101f3_0.conda
 
 https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 # Project metadata section. Provides the general ID information about the project.
 [project]
 name = "ataraxis-data-structures"
-version = "6.1.1"
+version = "6.1.2"
 description = "Provides classes and structures for storing, manipulating, and sharing data between Python processes."
 readme = "README.md"
 license = "Apache-2.0"
@@ -115,6 +115,7 @@ lint.ignore = [
     "PLW0603", # While global statement usage is not ideal, it streamlines certain development patterns
     "TID252",  # Conflicts with library import management strategy
     "ANN401",  # Interferes with intended library behavior
+    "CPY001",  # The license is declared in the LICENSE file and the project metadata
 ]
 
 # Additional formatting configurations

--- a/src/ataraxis_data_structures/data_structures/processing_tracker.py
+++ b/src/ataraxis_data_structures/data_structures/processing_tracker.py
@@ -215,8 +215,8 @@ class ProcessingTracker(YamlConfig):
             Foreign entries are detected against ``universe``, the full set of jobs the pipeline could produce,
             rather than against the requested subset. That distinction lets an invocation run part of a pipeline
             while its siblings keep their recorded state. A registry holding entries outside the universe means the
-            pipeline's own definition has changed since the tracker was written, so the registry is rebuilt and the
-            discarded IDs are reported through a warning.
+            pipeline's own definition has changed since the tracker was written, so those entries alone are
+            discarded and reported through a warning, and every in-universe job keeps its recorded state.
 
             Otherwise, the method additively registers any requested job the registry is missing, and is a no-op
             when every requested job is already present.
@@ -232,6 +232,7 @@ class ProcessingTracker(YamlConfig):
 
         Raises:
             TimeoutError: If the .LOCK file for the tracker .YAML file cannot be acquired within the timeout period.
+            ValueError: If any requested job is not part of the resolved universe.
         """
         resolved_universe = jobs if universe is None else universe
         universe_ids = {
@@ -241,6 +242,19 @@ class ProcessingTracker(YamlConfig):
             (self.generate_job_id(job_name=job_name, specifier=specifier), job_name, specifier)
             for job_name, specifier in jobs
         ]
+
+        out_of_universe = sorted(
+            f"{job_name} ({specifier})" if specifier else job_name
+            for job_id, job_name, specifier in requested
+            if job_id not in universe_ids
+        )
+        if out_of_universe:
+            message = (
+                f"Unable to align the processing tracker at '{self.file_path}' with the requested jobs. Every "
+                f"requested job must be part of the declared job universe, but the following are absent from it: "
+                f"{', '.join(out_of_universe)}."
+            )
+            console.error(message=message, error=ValueError)
 
         lock = FileLock(self.lock_path)
         with lock.acquire(timeout=10.0):
@@ -255,14 +269,15 @@ class ProcessingTracker(YamlConfig):
                 console.echo(
                     message=(
                         f"The processing tracker at '{self.file_path}' contains {len(foreign_ids)} job entries that "
-                        f"are not part of the current job universe. Rebuilding the tracker to match the requested "
-                        f"jobs. Discarded job IDs: {foreign_ids}."
+                        f"are not part of the current job universe. Discarding them and preserving every in-universe "
+                        f"job. Discarded job IDs: {foreign_ids}."
                     ),
                     level=LogLevel.WARNING,
                 )
                 if not was_enabled:
                     console.disable()
-                self.jobs.clear()
+                for foreign_id in foreign_ids:
+                    del self.jobs[foreign_id]
 
             # Registers the requested jobs that are absent, preserving the state of every job already tracked.
             for job_id, job_name, specifier in requested:
@@ -336,6 +351,8 @@ class ProcessingTracker(YamlConfig):
     def start_job(self, job_id: str, executor_id: str | None = None) -> None:
         """Marks the target job as running and records the identifier of the executor running it.
 
+        Clears the error message and completion timestamp recorded by any previous attempt at the job.
+
         Args:
             job_id: The unique identifier of the job to mark as started.
             executor_id: An optional explicit identifier for the executor running the job. When None (default), the
@@ -362,6 +379,8 @@ class ProcessingTracker(YamlConfig):
             # process ID) when the caller does not provide one explicitly.
             job_info = self.jobs[job_id]
             job_info.status = ProcessingStatus.RUNNING
+            job_info.error_message = None
+            job_info.completed_at = None
             job_info.executor_id = executor_id if executor_id is not None else self._resolve_executor_id()
             job_info.started_at = int(
                 get_timestamp(output_format=TimestampFormats.INTEGER, precision=TimestampPrecisions.MICROSECOND)
@@ -371,6 +390,8 @@ class ProcessingTracker(YamlConfig):
 
     def complete_job(self, job_id: str) -> None:
         """Marks a target job as successfully completed.
+
+        Clears the error message recorded by any previous attempt at the job.
 
         Args:
             job_id: The unique identifier of the job to mark as complete.
@@ -393,6 +414,7 @@ class ProcessingTracker(YamlConfig):
 
             job_info = self.jobs[job_id]
             job_info.status = ProcessingStatus.SUCCEEDED
+            job_info.error_message = None
             job_info.completed_at = int(
                 get_timestamp(output_format=TimestampFormats.INTEGER, precision=TimestampPrecisions.MICROSECOND)
             )
@@ -524,11 +546,15 @@ class ProcessingTracker(YamlConfig):
     def get_job_info(self, job_id: str) -> JobState:
         """Returns the full JobState object for the specified job.
 
+        Notes:
+            The returned state is a copy, so mutating it does not affect the tracker. Use the dedicated mutators to
+            change job state.
+
         Args:
             job_id: The unique identifier of the job to query.
 
         Returns:
-            The JobState object containing all metadata for the job.
+            A copy of the JobState object containing all metadata for the job.
 
         Raises:
             TimeoutError: If the .LOCK file for the tracker .YAML file cannot be acquired within the timeout period.
@@ -546,7 +572,8 @@ class ProcessingTracker(YamlConfig):
                 )
                 console.error(message=message, error=ValueError)
 
-            return self.jobs[job_id]
+            # Every JobState field is an immutable scalar, so replace() is a complete copy.
+            return replace(self.jobs[job_id])
 
     def reset_jobs(self, job_ids: list[str]) -> list[str]:
         """Resets the specified jobs back to SCHEDULED status, leaving every other job's state untouched.

--- a/tests/data_structures/processing_tracker_test.py
+++ b/tests/data_structures/processing_tracker_test.py
@@ -633,6 +633,97 @@ def test_processing_tracker_fail_job_with_error_message(tmp_path: Path) -> None:
     assert job_info.completed_at is not None
 
 
+def test_processing_tracker_start_job_clears_previous_attempt(tmp_path: Path) -> None:
+    """Verifies that start_job clears the error message and completion timestamp left by a previous attempt."""
+    tracker_file = tmp_path / "tracker.yaml"
+    tracker = ProcessingTracker(file_path=tracker_file)
+
+    job_id = ProcessingTracker.generate_job_id(job_name="test_job", specifier="")
+    tracker.initialize_jobs(jobs=[("test_job", "")])
+    tracker.start_job(job_id=job_id)
+    tracker.fail_job(job_id=job_id, error_message="CUDA out of memory")
+
+    tracker.start_job(job_id=job_id)
+
+    job_info = tracker.get_job_info(job_id=job_id)
+    assert job_info.status == ProcessingStatus.RUNNING
+    assert job_info.error_message is None
+    assert job_info.completed_at is None
+
+
+def test_processing_tracker_complete_job_clears_previous_error(tmp_path: Path) -> None:
+    """Verifies that complete_job clears the error message when a previously failed job succeeds."""
+    tracker_file = tmp_path / "tracker.yaml"
+    tracker = ProcessingTracker(file_path=tracker_file)
+
+    job_id = ProcessingTracker.generate_job_id(job_name="test_job", specifier="")
+    tracker.initialize_jobs(jobs=[("test_job", "")])
+    tracker.start_job(job_id=job_id)
+    tracker.fail_job(job_id=job_id, error_message="CUDA out of memory")
+
+    tracker.complete_job(job_id=job_id)
+
+    job_info = tracker.get_job_info(job_id=job_id)
+    assert job_info.status == ProcessingStatus.SUCCEEDED
+    assert job_info.error_message is None
+
+
+def test_processing_tracker_align_jobs_preserves_in_universe_siblings(tmp_path: Path) -> None:
+    """Verifies that discarding foreign entries leaves the recorded state of every in-universe job intact."""
+    tracker_file = tmp_path / "tracker.yaml"
+    tracker = ProcessingTracker(file_path=tracker_file)
+
+    universe = [("extract", "101"), ("extract", "152"), ("parse", "101-3-1")]
+    job_ids = tracker.align_jobs(jobs=universe, universe=universe)
+    for job_id in job_ids:
+        tracker.start_job(job_id=job_id)
+        tracker.complete_job(job_id=job_id)
+
+    # Simulates an entry left over from an earlier pipeline definition.
+    tracker.initialize_jobs(jobs=[("legacy_job", "")])
+    tracker.align_jobs(jobs=[("parse", "101-3-1")], universe=universe)
+
+    registry = tracker.snapshot()
+    assert set(registry) == set(job_ids)
+    assert registry[job_ids[0]].status == ProcessingStatus.SUCCEEDED
+    assert registry[job_ids[1]].status == ProcessingStatus.SUCCEEDED
+
+
+def test_processing_tracker_align_jobs_rejects_out_of_universe_request(tmp_path: Path) -> None:
+    """Verifies that requesting a job outside the declared universe raises and leaves the tracker untouched."""
+    tracker_file = tmp_path / "tracker.yaml"
+    tracker = ProcessingTracker(file_path=tracker_file)
+
+    universe = [("extract", "101"), ("parse", "101-3-1")]
+    job_ids = tracker.align_jobs(jobs=universe, universe=universe)
+    for job_id in job_ids:
+        tracker.start_job(job_id=job_id)
+        tracker.complete_job(job_id=job_id)
+
+    with pytest.raises(ValueError, match="absent from it"):
+        tracker.align_jobs(jobs=[("typo_job", "999")], universe=universe)
+
+    registry = tracker.snapshot()
+    assert set(registry) == set(job_ids)
+    assert all(job_state.status == ProcessingStatus.SUCCEEDED for job_state in registry.values())
+
+
+def test_processing_tracker_get_job_info_returns_a_copy(tmp_path: Path) -> None:
+    """Verifies that mutating the state returned by get_job_info leaves the tracker's registry unchanged."""
+    tracker_file = tmp_path / "tracker.yaml"
+    tracker = ProcessingTracker(file_path=tracker_file)
+
+    job_id = ProcessingTracker.generate_job_id(job_name="test_job", specifier="")
+    tracker.initialize_jobs(jobs=[("test_job", "")])
+
+    job_info = tracker.get_job_info(job_id=job_id)
+    job_info.status = ProcessingStatus.SUCCEEDED
+    job_info.error_message = "mutated by the caller"
+
+    assert tracker.get_job_info(job_id=job_id).status == ProcessingStatus.SCHEDULED
+    assert tracker.get_job_info(job_id=job_id).error_message is None
+
+
 def test_processing_tracker_get_jobs_by_status(tmp_path: Path) -> None:
     """Verifies that get_jobs_by_status returns correct job IDs."""
     tracker_file = tmp_path / "tracker.yaml"


### PR DESCRIPTION
-- Cleared stale error messages and completion timestamps in start_job and complete_job, so a job that succeeds on retry stops reporting its earlier failure. -- Changed align_jobs to discard only the foreign job entries, preserving the recorded state of every in-universe job. -- Added an align_jobs check that rejects requested jobs absent from the declared job universe. -- Changed get_job_info to return a copy of the job state, matching the copy semantics of snapshot. -- Added tests covering the retry, alignment, and copy semantics. -- Updated the README description of align_jobs behavior. -- Updated the development environment to ruff 0.16.0 and mypy 2.3.0, and ignored CPY001 since the license is declared in the LICENSE file and the project metadata. -- Bumped the project version to 6.1.2.