### PR TITLE
Fixed Windows link traversal and covered untested defensive branches.

### DIFF
--- a/src/ataraxis_data_structures/data_loggers/serialized_data_logger.py
+++ b/src/ataraxis_data_structures/data_loggers/serialized_data_logger.py
@@ -321,7 +321,7 @@ class DataLogger:
                 continue
 
             # Only checks that the process is alive if it is started.
-            if self._logger_process is not None and not self._logger_process.is_alive():  # pragma: no cover
+            if self._logger_process is not None and not self._logger_process.is_alive():
                 # Retires the instance in the same order stop() uses, clearing the started flag before releasing the
                 # terminator array. stop() reads that flag first and returns early once it is False, so a concurrent
                 # shutdown cannot reach the array after this thread has destroyed it.
@@ -704,7 +704,7 @@ def _compare_arrays(source_id: int, stem: str, original_array: NDArray[Any], arc
     Raises:
         ValueError: If the arrays do not match.
     """
-    if not np.array_equal(a1=original_array, a2=archived_array):  # pragma: no cover
+    if not np.array_equal(a1=original_array, a2=archived_array):
         message = (
             f"Unable to verify the integrity of the assembled log archive for source {source_id}. The archived data "
             f"for entry {stem} must exactly match the data of the original .npy log entry, but the two differ."

--- a/src/ataraxis_data_structures/data_structures/yaml_config.py
+++ b/src/ataraxis_data_structures/data_structures/yaml_config.py
@@ -196,13 +196,19 @@ def _collect_type_hooks(cls: type) -> dict[Any, Callable[[Any], Any]]:
             if isinstance(type_hint, UnionType) or get_origin(type_hint) is Union:
                 enum_targets: list[type] = []
                 for argument in type_arguments:
-                    if not isinstance(argument, type):  # pragma: no cover
-                        continue  # pragma: no cover
+                    # A generic member such as the 'list[str]' of a 'list[str] | None' annotation is not a class, so
+                    # it carries no enum to discriminate on and issubclass() below would reject it outright.
+                    if not isinstance(argument, type):
+                        continue
+                    # isinstance() accepts anything reporting 'type' as its class, while issubclass() additionally
+                    # demands a real '__bases__' tuple, so an import proxy standing in for an absent optional
+                    # dependency clears the guard above and fails here. Such a member carries no enum to
+                    # discriminate on, so the union is left without a hook rather than failing the whole load.
                     try:
                         if issubclass(argument, Enum) and argument is not Enum:
                             enum_targets.append(argument)
-                    except TypeError:  # pragma: no cover
-                        pass  # pragma: no cover
+                    except TypeError:
+                        pass
                 if enum_targets:
                     hooks[type_hint] = _make_union_enum_hook(enum_types=enum_targets)
 
@@ -233,15 +239,17 @@ def _collect_type_hooks(cls: type) -> dict[Any, Callable[[Any], Any]]:
             return
         visited.add(type_hint)
 
-        # Registers Path subclasses. dacite calls Path(str_value) during deserialization.
+        # Registers Path subclasses. dacite calls Path(str_value) during deserialization. An annotation that clears
+        # the guard above without satisfying issubclass() is left without a hook, as described in the union walk.
         try:
             if issubclass(type_hint, Path):
                 hooks[type_hint] = type_hint
                 return
-        except TypeError:  # pragma: no cover
-            return  # pragma: no cover
+        except TypeError:
+            return
 
-        # Registers Enum subclasses (but not the abstract Enum base itself).
+        # Registers Enum subclasses (but not the abstract Enum base itself). The Path check above shields this one,
+        # since an annotation that answers it without raising has the '__bases__' tuple this check also needs.
         try:
             if issubclass(type_hint, Enum) and type_hint is not Enum:
                 hooks[type_hint] = type_hint
@@ -259,10 +267,12 @@ def _collect_type_hooks(cls: type) -> dict[Any, Callable[[Any], Any]]:
         Args:
             dataclass_type: The dataclass type whose field annotations should be walked.
         """
+        # An annotation naming a type this module cannot resolve leaves the class without a hook rather than failing
+        # the load, since the fields that do resolve still deserialize through the hooks the walk collected.
         try:
             hints = get_type_hints(dataclass_type)
-        except (TypeError, NameError, AttributeError):  # pragma: no cover
-            return  # pragma: no cover
+        except (TypeError, NameError, AttributeError):
+            return
 
         for hint_type in hints.values():
             _walk_type(type_hint=hint_type)

--- a/src/ataraxis_data_structures/processing/filesystem_tools.py
+++ b/src/ataraxis_data_structures/processing/filesystem_tools.py
@@ -12,8 +12,8 @@ from ataraxis_base_utilities import console
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-ABSENT_ENTRY_ERRNOS: frozenset[int] = frozenset({errno.ENOENT, errno.ENOTDIR, errno.EBADF, errno.ELOOP})
-"""The metadata-query failures that answer as an absent entry rather than propagating.
+_ABSENT_ENTRY_ERRNOS: frozenset[int] = frozenset({errno.ENOENT, errno.ENOTDIR, errno.EBADF, errno.ELOOP})
+"""The metadata-query error numbers that answer as an absent entry rather than propagating.
 
 Notes:
     An entry that disappears between its discovery and its inspection has to read as absent, since discovery and
@@ -22,6 +22,20 @@ Notes:
 
     Every other failure, a permission error above all, means the entry exists while its kind stays unknown. Answering
     that case as absent would drop the entry from a result meant to cover the whole tree.
+"""
+
+_ABSENT_ENTRY_WINERRORS: frozenset[int] = frozenset({1921})
+"""The Windows status codes that answer as an absent entry rather than propagating.
+
+Notes:
+    Windows reports a link chain that does not resolve as ERROR_CANT_RESOLVE_FILENAME (1921), which the interpreter
+    surfaces under the generic EINVAL rather than under ELOOP. The ELOOP name additionally carries an unrelated socket
+    value on Windows, so the status code is what separates a looping link from a genuine argument error there.
+
+    Windows files every unfollowable link under this one status, so a link the host is merely configured not to
+    follow reads as absent alongside a link that genuinely loops. Reporting a looping link as no file is what the
+    traversal contract promises on every platform, and the permission and sharing failures that must keep
+    propagating carry their own distinct status codes.
 """
 
 
@@ -178,6 +192,20 @@ def resolve_unique_roots(paths: list[Path] | tuple[Path, ...]) -> tuple[Path, ..
     return tuple(roots)
 
 
+def reports_absent_entry(error: OSError) -> bool:
+    """Determines whether the target metadata-query failure answers as an absent entry.
+
+    Args:
+        error: The failure raised by the metadata query.
+
+    Returns:
+        True when the failure names an entry that does not resolve, and False when the entry exists while its kind
+        stays unknown.
+    """
+    # The Windows status is read through getattr, since OSError carries the attribute on that platform alone.
+    return error.errno in _ABSENT_ENTRY_ERRNOS or getattr(error, "winerror", None) in _ABSENT_ENTRY_WINERRORS
+
+
 def _extract_unique_components(paths: list[Path]) -> tuple[str, ...]:
     """Extracts the deepest component of each target path that no other target path carries.
 
@@ -259,6 +287,6 @@ def _resolves_to_file(entry: os.DirEntry[str]) -> bool:
     try:
         return entry.is_file()
     except OSError as error:
-        if error.errno not in ABSENT_ENTRY_ERRNOS:
+        if not reports_absent_entry(error=error):
             raise
         return False

--- a/src/ataraxis_data_structures/processing/transfer_tools.py
+++ b/src/ataraxis_data_structures/processing/transfer_tools.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from ataraxis_time import PrecisionTimer, TimerPrecisions
-from ataraxis_base_utilities import console, resolve_worker_count, ensure_directory_exists
+from ataraxis_base_utilities import LogLevel, console, resolve_worker_count, ensure_directory_exists
 
 from .checksum_tools import CHECKSUM_FILENAME, calculate_directory_checksum
-from .filesystem_tools import ABSENT_ENTRY_ERRNOS, walk_files, walk_directory
+from .filesystem_tools import walk_files, walk_directory, reports_absent_entry
 
 _MAXIMUM_DELETION_ATTEMPTS: int = 5
 """The maximum number of times directory deletion is retried before giving up."""
@@ -29,8 +29,8 @@ def delete_directory(directory_path: Path) -> None:
 
         Removal of each emptied directory is attempted up to five times, with a 500 millisecond delay between
         attempts, as some Operating Systems are slow to release file handles. If every attempt fails, the function
-        returns without raising an error and the directory is left in place. Check the path with Path.exists() when
-        the removal has to be guaranteed.
+        reports a warning and returns, leaving the directory in place. Check the path with Path.exists() when the
+        removal has to be guaranteed.
 
     Args:
         directory_path: The path to the directory to delete.
@@ -65,9 +65,19 @@ def delete_directory(directory_path: Path) -> None:
         try:
             directory_path.rmdir()
             break
-        except Exception:  # pragma: no cover
+        except Exception:
             delay_timer.delay(block=False, delay=_DELETION_RETRY_DELAY_MILLISECONDS, allow_sleep=True)
             continue
+    else:
+        # Exhausting every attempt leaves a directory that the caller has been told is gone, so the outcome is
+        # reported rather than returned silently. It stays a warning, since the data the caller asked to remove is
+        # still intact and every caller that needs the removal is able to verify the path itself.
+        message = (
+            f"Unable to remove the {directory_path} directory after {_MAXIMUM_DELETION_ATTEMPTS} attempts. The "
+            f"directory is left in place, which typically indicates that another process still holds an open handle "
+            f"to it or to one of the entries it stored."
+        )
+        console.echo(message=message, level=LogLevel.WARNING)
 
 
 def transfer_directory(
@@ -212,7 +222,7 @@ def transfer_directory(
                 )
                 for file in file_list
             ]
-            if progress:  # pragma: no cover
+            if progress:
                 with console.progress(
                     total=len(file_list),
                     description=f"Transferring files to {destination.name}",
@@ -300,7 +310,7 @@ def _classify_entry(path: Path) -> tuple[bool, bool]:
         One lstat call answers both questions. Since lstat reports a link rather than its target, a symbolic link
         answers False to the directory question whatever it points at.
 
-        An entry whose metadata query fails with one of the ``ABSENT_ENTRY_ERRNOS`` answers False to both questions,
+        An entry whose metadata query fails in a way ``reports_absent_entry`` accepts answers False to both questions,
         which covers an entry that disappears between its discovery and this call. Every other failure propagates,
         since an entry that exists but cannot be read has an unknown kind rather than no kind.
 
@@ -316,7 +326,7 @@ def _classify_entry(path: Path) -> tuple[bool, bool]:
     try:
         entry_mode = os.lstat(path).st_mode
     except OSError as error:
-        if error.errno not in ABSENT_ENTRY_ERRNOS:
+        if not reports_absent_entry(error=error):
             raise
         return False, False
     return stat.S_ISLNK(entry_mode), stat.S_ISDIR(entry_mode)

--- a/tests/data_loggers/serialized_data_logger_test.py
+++ b/tests/data_loggers/serialized_data_logger_test.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from ataraxis_base_utilities import LogLevel, console, error_format
 
-from ataraxis_data_structures import DataLogger, LogPackage, assemble_log_archives
+from ataraxis_data_structures import DataLogger, LogPackage, SharedMemoryArray, assemble_log_archives
 from ataraxis_data_structures.data_loggers.serialized_data_logger import _compare_arrays, _progress_display
 
 if TYPE_CHECKING:
@@ -266,6 +266,33 @@ def test_data_logger_start_stop_cycling(tmp_path: Path) -> None:
 
 
 @pytest.mark.xdist_group(name="group1")
+def test_data_logger_watchdog_reports_a_prematurely_shut_down_process(tmp_path: Path) -> None:
+    """Verifies that the watchdog raises when the logger process exits before the shutdown command is issued."""
+    logger = DataLogger(output_directory=tmp_path, instance_name="watchdog_logger")
+
+    # Builds the state the watchdog monitors without start(), which would also run the check on its own thread, where
+    # the error it raises is unobservable and the resources it releases race the ones this test releases.
+    terminator_array = SharedMemoryArray.create_array(
+        name="watchdog_logger_terminator", prototype=np.zeros(shape=1, dtype=np.uint8), exists_ok=True
+    )
+    logger._terminator_array = terminator_array
+    logger._logger_process = _ExitedProcess()
+    logger._started = True
+
+    message = (
+        "Remote logger process for the watchdog_logger DataLogger has been prematurely shut down. This likely "
+        "indicates that the process has encountered a runtime error."
+    )
+    with pytest.raises(ChildProcessError, match=error_format(message)):
+        logger._watchdog()
+
+    # The watchdog retires the instance before reporting, so the terminator array is released and stop() has no
+    # shutdown work left to repeat.
+    assert not logger._started
+    assert not logger.alive
+
+
+@pytest.mark.xdist_group(name="group1")
 def test_data_logger_failed_write(
     tmp_path: Path, sample_data: tuple[int, int, NDArray[np.uint8]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -505,3 +532,19 @@ def _raise_probe_error() -> None:
     """Raises an error so a test can observe how the surrounding context manager handles an exceptional exit."""
     message = "simulated failure"
     raise RuntimeError(message)
+
+
+class _ExitedProcess:
+    """Stands in for a logger process that has already shut down.
+
+    The exit code is what stop() reads, so the stand-in carries one to keep a watchdog regression surfacing as a
+    failed assertion rather than as an AttributeError the destructor swallows.
+    """
+
+    exitcode = 0
+
+    def is_alive(self) -> bool:
+        return False
+
+    def join(self, timeout: float | None = None) -> None:
+        """Accepts the join without waiting, since the stand-in process is already gone."""

--- a/tests/data_structures/yaml_config_test.py
+++ b/tests/data_structures/yaml_config_test.py
@@ -1,7 +1,7 @@
 """Contains tests for classes and methods provided by the yaml_config.py module."""
 
 from enum import IntEnum, StrEnum
-from typing import Any, Optional
+from typing import Any, Union, Optional
 from pathlib import Path
 from dataclasses import field, dataclass
 
@@ -526,6 +526,83 @@ def test_collect_type_hooks_union_enum() -> None:
     int_priority_hook = hooks[int | Priority]
     assert int_priority_hook(1) is Priority.LOW
     assert int_priority_hook(99) == 99
+
+
+def test_collect_type_hooks_skips_a_generic_union_member() -> None:
+    """Verifies that _collect_type_hooks registers the enum of a union whose other member is a generic alias."""
+
+    @dataclass
+    class GenericUnionConfig(YamlConfig):
+        # 'list[str]' is a generic alias rather than a class, so the union walk steps over it to reach the enum.
+        items: list[str] | None = None
+        tint: Color | None = None
+
+    hooks = _collect_type_hooks(cls=GenericUnionConfig)
+
+    assert Color in hooks
+    assert (Color | None) in hooks
+
+
+class _ImportProxy:
+    """Stands in for a module-level import proxy used in place of an absent optional dependency.
+
+    Notes:
+        Reporting 'type' as its class is what makes isinstance() accept the proxy as a class, while the absent
+        '__bases__' tuple is what makes issubclass() reject it. Annotating a field with such a proxy is the
+        realistic way a dataclass reaches the type hook walk's issubclass failure handlers.
+
+        The name attributes are what the dataclass machinery reads when it renders the annotation, which every
+        object standing in for a class carries.
+    """
+
+    def __init__(self) -> None:
+        self.__qualname__ = "_ImportProxy"
+
+    @property
+    def __class__(self) -> type:  # type: ignore[override]
+        return type
+
+    def __call__(self, *arguments: object, **keywords: object) -> None:
+        """Accepts the construction call that typing performs when it validates a union member."""
+
+
+def test_collect_type_hooks_skips_a_union_member_that_is_not_a_real_class() -> None:
+    """Verifies that _collect_type_hooks registers the enum of a union whose other member fails the subclass check."""
+    proxy = _ImportProxy()
+
+    # The proxy is not a real class, so the union is built through typing rather than through the '|' operator.
+    annotation = Union[Color, proxy]  # noqa: UP007 - The '|' operator rejects a member that is not a real class.
+
+    @dataclass
+    class ProxyUnionConfig(YamlConfig):
+        tint: annotation = Color.RED  # type: ignore[valid-type]
+
+    hooks = _collect_type_hooks(cls=ProxyUnionConfig)
+
+    # The proxy is stepped over rather than aborting the walk, so the real enum member still earns its hooks.
+    assert Color in hooks
+    assert hooks[annotation]("red") is Color.RED
+
+
+def test_collect_type_hooks_returns_no_hook_for_an_annotation_that_is_not_a_real_class() -> None:
+    """Verifies that _collect_type_hooks answers with no hook for a field annotated with an import proxy."""
+
+    @dataclass
+    class ProxyConfig(YamlConfig):
+        value: _ImportProxy() = None  # type: ignore[valid-type]
+
+    assert _collect_type_hooks(cls=ProxyConfig) == {}
+
+
+def test_collect_type_hooks_returns_no_hook_for_an_unresolvable_annotation() -> None:
+    """Verifies that _collect_type_hooks answers with no hook for a class whose annotations do not resolve."""
+
+    @dataclass
+    class UnresolvableConfig(YamlConfig):
+        # The annotation names a type that exists nowhere, so resolving the class hints raises rather than returning.
+        value: "NeverDefinedType" = None  # type: ignore[name-defined]  # noqa: F821 - Intentionally unresolvable.
+
+    assert _collect_type_hooks(cls=UnresolvableConfig) == {}
 
 
 def test_to_yaml_leaves_previous_file_intact_when_the_dump_fails(

--- a/tests/processing/filesystem_tools_test.py
+++ b/tests/processing/filesystem_tools_test.py
@@ -176,6 +176,27 @@ def test_walk_files_tolerates_a_kind_failure_that_means_absence(
     assert walk_files(directory=tmp_path) == []
 
 
+def test_walk_files_tolerates_the_windows_link_loop_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verifies that walk_files omits an entry whose kind query reports the Windows link-loop status."""
+    # Windows files the condition under the generic EINVAL, which every other caller has to keep propagating, so the
+    # status code is the only part of the failure that marks the entry as unresolvable.
+    entry = _RefusingEntry(path=tmp_path / "loop_a", error_number=errno.EINVAL, error_type=_WindowsLinkLoopError)
+    monkeypatch.setattr(target=os, name="scandir", value=lambda _path: _StubScan(entries=[entry]))
+
+    assert walk_files(directory=tmp_path) == []
+
+
+def test_walk_files_propagates_an_invalid_argument_failure_without_the_link_loop_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verifies that walk_files raises for an EINVAL kind query that does not carry the link-loop status."""
+    entry = _RefusingEntry(path=tmp_path / "entry.bin", error_number=errno.EINVAL, error_type=OSError)
+    monkeypatch.setattr(target=os, name="scandir", value=lambda _path: _StubScan(entries=[entry]))
+
+    with pytest.raises(OSError, match="Injected failure"):
+        walk_files(directory=tmp_path)
+
+
 def test_walk_files_raises_for_an_unreadable_subdirectory(unreadable_tree: Path) -> None:
     """Verifies that walk_files raises instead of silently omitting a subdirectory it cannot read."""
     with pytest.raises(PermissionError):
@@ -317,23 +338,37 @@ class _StubScan:
         return False
 
 
+class _WindowsLinkLoopError(OSError):
+    """Stands in for the failure Windows raises for a link chain that does not resolve.
+
+    Notes:
+        Windows carries the condition in the read-only 'winerror' attribute, which POSIX hosts do not define at all.
+        Shadowing it with a plain class attribute makes the injected failure read alike on every platform, so the
+        status the traversal reads is exercised wherever the suite runs.
+    """
+
+    winerror = 1921
+
+
 class _RefusingEntry:
-    """Stands in for a scan entry whose kind query fails with the errno the test supplies.
+    """Stands in for a scan entry whose kind query fails with the error the test supplies.
 
     Attributes:
         path: The rendered path of the stand-in entry.
         _error_number: Cached errno the kind query fails with.
+        _error_type: Cached exception class the kind query raises.
     """
 
-    def __init__(self, path: Path, error_number: int) -> None:
+    def __init__(self, path: Path, error_number: int, error_type: type[OSError] = PermissionError) -> None:
         self.path = str(path)
         self._error_number = error_number
+        self._error_type = error_type
 
     def is_dir(self, *, follow_symlinks: bool = True) -> bool:  # noqa: ARG002 - The stub entry is never a directory.
         return False
 
     def is_file(self) -> bool:
-        raise PermissionError(self._error_number, "Injected failure", self.path)
+        raise self._error_type(self._error_number, "Injected failure", self.path)
 
 
 def test_discover_marker_files_reports_matches_at_any_depth(tmp_path: Path) -> None:

--- a/tests/processing/transfer_tools_test.py
+++ b/tests/processing/transfer_tools_test.py
@@ -6,6 +6,7 @@ from typing import Any
 from pathlib import Path
 
 import pytest
+from ataraxis_base_utilities import LogLevel, console
 
 from ataraxis_data_structures import (
     delete_directory,
@@ -608,6 +609,78 @@ def test_transfer_directory_integrity_check_with_progress(sample_directory_struc
 
     # Verifies the checksum file exists.
     assert (source / "ax_checksum.txt").exists()
+
+
+def test_transfer_directory_multithreaded_with_progress(sample_directory_structure: Path, tmp_path: Path) -> None:
+    """Verifies that a multithreaded transfer reports progress while copying every file."""
+    destination = tmp_path / "dest_multithreaded_progress"
+
+    # The progress bar wraps the completion of the submitted futures, which is a separate loop from the one the
+    # single-threaded transfer tracks, so reaching it takes both a thread count above one and progress enabled.
+    transfer_directory(
+        source=sample_directory_structure,
+        destination=destination,
+        num_threads=4,
+        progress=True,
+    )
+
+    assert (destination / "file1.txt").read_text() == "content1"
+    assert (destination / "subdir1" / "file3.txt").read_text() == "content3"
+    assert (destination / "subdir1" / "nested" / "file6.txt").read_text() == "content6"
+
+
+def test_delete_directory_retries_a_refused_removal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verifies that directory removal retries after an attempt that the filesystem refuses."""
+    target = tmp_path / "retried"
+    target.mkdir()
+    (target / "data.txt").write_text("payload")
+
+    real_rmdir = Path.rmdir
+    attempts: list[str] = []
+
+    def _refuse_first_attempt(self: Path) -> None:
+        # Windows refuses the removal while a handle to a just-unlinked entry is still open, which is the transient
+        # failure the retry loop absorbs.
+        attempts.append(str(self))
+        if len(attempts) == 1:
+            raise PermissionError(errno.EACCES, "Injected failure", str(self))
+        real_rmdir(self)
+
+    monkeypatch.setattr(target=Path, name="rmdir", value=_refuse_first_attempt)
+
+    delete_directory(directory_path=target)
+
+    assert len(attempts) > 1
+    assert not target.exists()
+
+
+def test_delete_directory_warns_when_every_removal_attempt_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verifies that directory removal reports a warning when it exhausts every attempt."""
+    target = tmp_path / "undeletable"
+    target.mkdir()
+    (target / "data.txt").write_text("payload")
+
+    def _refuse_every_attempt(self: Path) -> None:
+        raise PermissionError(errno.EACCES, "Injected failure", str(self))
+
+    monkeypatch.setattr(target=Path, name="rmdir", value=_refuse_every_attempt)
+
+    # Records the console call directly, since loguru writes through a stream reference that the pytest capture
+    # fixtures do not intercept.
+    reported: list[tuple[str, str]] = []
+    monkeypatch.setattr(console, "echo", lambda message, level: reported.append((message, level)))
+
+    delete_directory(directory_path=target)
+
+    assert len(reported) == 1
+    reported_message, reported_level = reported[0]
+    assert reported_level == LogLevel.WARNING
+    assert f"Unable to remove the {target} directory after 5 attempts" in reported_message
+
+    # The warning stands in for the removal, so the directory survives while its contents are already unlinked.
+    assert target.exists()
 
 
 def test_transfer_directory_creates_checksum_when_missing(tmp_path: Path) -> None:

--- a/tests/shared_memory/shared_memory_array_test.py
+++ b/tests/shared_memory/shared_memory_array_test.py
@@ -405,18 +405,48 @@ def test_creating_process_arms_buffer_destruction(int_array: NDArray[np.int32]) 
     recreated.destroy()
 
 
-def test_recreating_a_name_revokes_the_previous_owner(int_array: NDArray[np.int32], spawning: None) -> None:
+def test_recreating_a_name_revokes_the_previous_owner(
+    int_array: NDArray[np.int32], monkeypatch: pytest.MonkeyPatch, spawning: None
+) -> None:
     """Verifies that recreating a buffer name strips the destruction right from the instance that held it.
 
     Unlinking addresses a buffer by name, so a superseded instance that kept its destruction right would unlink the
-    replacement buffer rather than its own once garbage collection reached it.
+    replacement buffer rather than its own once garbage collection reached it. Unix is where a lost right corrupts the
+    replacement, since unlink() is a no-op on Windows, so the assertions below detect the regression on Unix and
+    exercise the revocation itself on every platform.
     """
     buffer_name = "test_ownership_transfer"
     superseded = SharedMemoryArray.create_array(name=buffer_name, prototype=int_array)
 
+    # Hands the superseded instance to the patched unlink through a container the collection below does not reach.
+    # Referencing the test's own local would fail instead, since deleting it clears the closure the patch reads.
+    pending_release = [superseded]
+
+    class OwnerReleasingSharedMemory(SharedMemory):
+        """Releases the superseded instance's buffer handle whenever a shared memory buffer is unlinked."""
+
+        def unlink(self) -> None:
+            """Unlinks the shared memory buffer and releases the handle held by the superseded instance."""
+            super().unlink()
+            # Unix frees the buffer name through unlink() alone, while Windows keeps it claimed until the last handle
+            # to the buffer closes. Releasing the superseded instance's handle brings both platforms to the same
+            # post-unlink state, so the recreation below runs identically on each. Draining the container also drops
+            # this reference, which leaves the test's own local as the instance's last one.
+            while pending_release:
+                pending_release.pop().disconnect()
+
+    monkeypatch.setattr(
+        target="ataraxis_data_structures.shared_memory.shared_memory_array.SharedMemory",
+        name=OwnerReleasingSharedMemory,
+    )
+
     # Rebinds the name onto a new buffer while the first instance is still alive.
     replacement = SharedMemoryArray.create_array(name=buffer_name, prototype=int_array, exists_ok=True)
     replacement[0] = 123
+
+    # Asserting the revocation directly is what fails on Windows, where unlink() is a no-op and the observer check
+    # below therefore cannot detect a superseded instance that kept its right.
+    assert not superseded._destroy_buffer
 
     # Collecting the superseded instance runs the destruction path that would unlink the replacement's buffer.
     del superseded


### PR DESCRIPTION
-- Added a shared absent-entry predicate that reads the Windows ERROR_CANT_RESOLVE_FILENAME status, so a looping symbolic link reports as no file rather than aborting the traversal that finds it. -- Added a warning to delete_directory for the case where every removal attempt fails, so a directory left in place no longer reads as removed. -- Replaced the coverage exclusions over the YAML type-hook walk with tests covering its non-class union members, unresolvable annotations, and failed subclass checks. -- Replaced the coverage exclusions over the multithreaded transfer progress bar, the directory removal retry, the logger watchdog shutdown, and the archive comparison mismatch with tests reaching each one. -- Updated the shared memory ownership test and the unresolvable link test to exercise the same paths on Windows and Unix.